### PR TITLE
Comment spec

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -9,18 +9,18 @@ class Comment < ActiveRecord::Base
 
   after_save :send_mentions
 
-  def send_mentions # spec_me cover_me heckle_me
+  def send_mentions # heckle_me
     Mention.parse(self, self.author_id)
   end
 
-  def title # spec_me cover_me heckle_me
+  def title # heckle_me
     case self.commented_type
     when "News"
       self.commented.title
     end
   end
 
-  def mention(mentioner_id, mentioned_id, mention_text) # spec_me cover_me heckle_me
+  def mention(mentioner_id, mentioned_id, mention_text) # heckle_me
     Notification.create :recipient_id => mentioned_id,
                         :variation => 'mention',
                         :params => {:mention_text => self.comments,

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -1,40 +1,60 @@
 require 'spec_helper'
 
 describe Comment do
-  let(:author) { User.create!(:foreign_key => 'author_id') }
+
+  let(:author) { Factory.create(:user) }
+  let(:comment) { Comment.new(:author => author) }
 
   describe "associations" do
     it { should belong_to(:author) }
     it { should belong_to(:commented) }
   end
 
-  [:commented].each do |attr|
-    it { should validate_presence_of(attr) }
+  describe 'validations' do
+    it { should validate_presence_of(:commented) }
   end
 
-  describe 'notifications' do
-    with_args = { :sender_id => 10, :recipient_id => 11, :params => { :mention_text => "10 mentioned 11" }}
-    let(:comment) { Comment.new }
-    let(:notification) { Notification.create(with_args) }
+  describe '#send_mentions' do
+    it 'should send mention of itself' do
+      Mention.should_receive(:parse).with(comment, author.id)
+      comment.send_mentions
+    end
+  end
 
-    describe "#mention" do
-      it 'creates a notification' do
-        # mentioner_id = 10, mentioned_id = 11, mention_text = "10 mentioned 11"
-        comment.stub(:mention).and_return notification
+  describe '#title' do
+    context "When commented type is 'News'" do
+      let(:news) {
+        News.create!( :title => "Rob is cool",
+                      :description => "Comment by dklounge")
+      }
+
+      it 'returns the title of the news item' do
+        comment.commented = news
+        comment.commented.title.should == "Rob is cool"
       end
-      # it 'creates a new notification' do
-      #   comment = Comment.new(..some params..)
-      #   comment.stub(:send_mentions)
-      #   comment.save!
-      #   expect {
-      #     comment.mention(..params..)
-      #   }.to change(Notification, :count).by(1)
+    end
+  end
 
-      #   # then the same as above
-      #   notification = Notification.last
-      #   notification.recipient.should == comment.author
-      #   # ...and so on, verifying the other attributes on the notification...
-      # end
+  describe "#mention" do
+    let(:params) { {:mention_text => "10 mentioned 11"} }
+    let(:sender_id) { 10 }
+    let(:recipient_id) { 11 }
+    let(:notification) { Notification.create(comment_args) }
+
+    it 'creates a new notification' do
+      expect {
+        comment.mention(sender_id, recipient_id, params)
+      }.to change(Notification, :count).by(1)
+    end
+
+    it 'sends notification from correct sender' do
+      comment.mention(sender_id, recipient_id, params)
+      Notification.last.sender_id.should == sender_id
+    end
+
+    it 'sends notification to correct recipient' do
+      comment.mention(sender_id, recipient_id, params)
+      Notification.last.recipient_id.should == recipient_id
     end
 
   end


### PR DESCRIPTION
Completed spec - I think the third parameter `mention_text` in `mention` method may be a bug, because in the Notification that is created is:

```
:mention_text => self.comments (line 26)
```

which means that it is assigned whatever self.comments are independent of the argument that is passed in. That seemed to be the case when I tested it out in console.
