### PR TITLE
add mac-specific rb-fsevent gem for guard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,8 @@ group :test do
 end
 
 group :development do
-  gem 'rb-inotify', '~> 0.8.8'
+  gem 'rb-inotify', '~> 0.8.8', :require => false
+  gem 'rb-fsevent', :require => false
   gem 'brakeman', :require => false
   gem 'guard-rspec'
   gem 'spork', '0.8.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,7 @@ GEM
       activesupport (= 2.3.18)
       rake (>= 0.8.3)
     rake (0.8.7)
+    rb-fsevent (0.9.4)
     rb-inotify (0.8.8)
       ffi (>= 0.5.0)
     rbx-require-relative (0.0.9)
@@ -124,7 +125,7 @@ GEM
     reportable (1.1.2)
       activerecord (>= 2.0.0)
       activesupport (>= 2.0.0)
-    rmagick (2.13.1)
+    rmagick (2.13.3)
     rpx_now (0.6.24)
       json_pure
     rspec (1.3.2)
@@ -195,6 +196,7 @@ DEPENDENCIES
   rack-timeout (= 0.0.1)
   rails (= 2.3.18)
   rake (= 0.8.7)
+  rb-fsevent
   rb-inotify (~> 0.8.8)
   rcov
   recurly (= 0.3.3)


### PR DESCRIPTION
Added rb-fsevent gem for mac-specific platforms. This is in response to receiving 'inotify not found' errors on a mac. 
