### PR TITLE
Add spec and fixed bug in User#lock_workstreams?

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -230,8 +230,10 @@ class User < ActiveRecord::Base
     super
   end
 
-  def lock_workstreams? # spec_me cover_me heckle_me
-    (self.usage_over_at && self.usage_over_at.advance(:days => -1 * Setting::WORKSTREAM_LOCK_THRESHOLD) > DateTime.now) || (self.trial_expired_at && self.trial_expired_at.advance(:days => -1 *  Setting::WORKSTREAM_LOCK_THRESHOLD) > DateTime.now)
+  def lock_workstreams? # heckle_me
+    lock_threshold_date = Setting::WORKSTREAM_LOCK_THRESHOLD.days.ago
+    (self.usage_over_at? && self.usage_over_at < lock_threshold_date) ||
+      (self.trial_expired_at? && self.trial_expired_at < lock_threshold_date)
   end
 
   #detects if usage is way over, or trial has expired for a while, and locks out private workstreams belonging to user

--- a/spec/models/user/lock_workstreams_predicate_spec.rb
+++ b/spec/models/user/lock_workstreams_predicate_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe User, '#lock_workstreams?' do
+
+  let(:user) { Factory.build(:user) }
+
+  it "returns false when usage and trial are not over" do
+    user.lock_workstreams?.should be false
+  end
+
+  it "returns false when usage is over but not past the grace period" do
+    user.usage_over_at = 1.day.ago
+    user.lock_workstreams?.should be false
+  end
+
+  it "returns true when usage is over and past the grace period" do
+    user.usage_over_at = 31.days.ago
+    user.lock_workstreams?.should be true
+  end
+
+  it "returns false when trial is expired but not past the grace period" do
+    user.trial_expired_at = 1.day.ago
+    user.lock_workstreams?.should be false
+  end
+
+  it "returns true when trial is expired and past the grace period" do
+    user.trial_expired_at = 31.days.ago
+    user.lock_workstreams?.should be true
+  end
+
+end


### PR DESCRIPTION
The way it was written, it was checking if usage_over_at and trial_expired were in the future.
We changed it so that it checks that they are 30 days or more in the past before locking workstreams.