### PR TITLE
Fix inconsistent model tests

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -555,7 +555,15 @@ class Issue < ActiveRecord::Base
   private
 
   def lazy_majority_passed?
-    updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
+    # Convert to string because date comparison was flaky. For some reason even
+    # when there was an entire day of separation, this comparison would
+    # seemingly randomly return `true` or `false` running this same check over
+    # and over. Converting with `to_s` turns this into a string comparison
+    # instead, which seems to be reliable. This problem may go away after
+    # upgrading beyond Ruby 1.8.7 or Rails 2.3, so we may be able to revert back
+    # to simple date comparison rather than using `to_s`.
+    updated_at.to_datetime.to_s(:iso8601) <
+      (DateTime.now - Setting::LAZY_MAJORITY_LENGTH).to_s(:iso8601)
   end
 
   # Callback on attachment deletion


### PR DESCRIPTION
For some reason `Issue#lazy_majority_passed?` was super flaky. It was
returning `true` or `false` seemingly at random. When I put in a
debugger, I got similar results when doing the date/time comparison
repeatedly:

```irb
(rdb:1) updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
true
(rdb:1) updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
true
(rdb:1) updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
false
(rdb:1) updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
false
(rdb:1) updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
false
(rdb:1) updated_at < DateTime.now - Setting::LAZY_MAJORITY_LENGTH
true
```

I poked around with different options, converting to UTC and so forth,
but the same issue presented itself. There's more than 24 hours between
the values, so time zones shouldn't be an issue anyway. I settled on
converting to string, which I feel pretty confident works as expected.
The tests passed consistently over several runs, at any rate.

I suspect this is an obscure bug in `ActiveSupport`, but didn't feel it
was worth too deep an investigation, because, *fingers crossed*, this
issue will hopefully have been resolved in a more recent version of
Ruby/Rails.

I needed to convert `updated_at.to_datetime` because
`updated_at.to_s(:iso8601)` returns a string in a different format that
is not lexically sortable. It starts with the day of the week, `Sat`,
`Sun`, etc.
