### PR TITLE
fix flake in issue_add_spec

### DIFF
--- a/spec/models/mailer/issue_add_spec.rb
+++ b/spec/models/mailer/issue_add_spec.rb
@@ -57,7 +57,7 @@ describe Mailer, '#issue_add' do
     user_2.add_as_core(issue.project)
 
     mail = Mailer.deliver_issue_add(issue)
-    mail.bcc.sort.should == [user.mail, user_2.mail]
+    mail.bcc.sort.should == [user.mail, user_2.mail].sort
   end
 
 end


### PR DESCRIPTION
This one [failed][fail] when the sequence in the users factory went from
9 to 10, changing the sort order. As near as I can tell, there doesn't
appear to be an order applied in the code, so this sorts both arrays.

[fail]: https://app.circleci.com/pipelines/github/mockdeep/better/48/workflows/c22f1d7a-59ba-48ea-ae56-ac5d23762517/jobs/56
