### PR TITLE
write tests for MailsController#delete_selected

### DIFF
--- a/app/controllers/mails_controller.rb
+++ b/app/controllers/mails_controller.rb
@@ -40,17 +40,15 @@ class MailsController < ApplicationController
     end
   end
 
-  def delete_selected # spec_me cover_me heckle_me
-    if request.post?
-      if params[:delete]
-        params[:delete].each { |id|
-          @mail = Mail.find(:first, :conditions => ["mails.id = ? AND (sender_id = ? OR recipient_id = ?)", id, @user, @user])
-          @mail.mark_deleted(@user) unless @mail.nil?
-        }
-        flash.now[:success] = "Messages deleted"
-      end
-      redirect_to user_mail_path(@user, @mails)
+  def delete_selected # cover_me heckle_me
+    if params[:delete]
+      params[:delete].each { |id|
+        @mail = Mail.find(:first, :conditions => ["mails.id = ? AND (sender_id = ? OR recipient_id = ?)", id, @user, @user])
+        @mail.mark_deleted(@user) unless @mail.nil?
+      }
+      flash[:success] = "Messages deleted"
     end
+    redirect_to user_mails_path(@user)
   end
 
   private

--- a/spec/controllers/mails_controller/delete_selected_spec.rb
+++ b/spec/controllers/mails_controller/delete_selected_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+
+describe MailsController, '#delete_selected' do
+  it 'redirects to user_mail_path when no params[:delete] given' do
+    post(:delete_selected)
+
+    response.should redirect_to user_mails_path(User.anonymous)
+  end
+
+  it 'marks each mail deleted when user is sender' do
+    user = User.anonymous
+    mail_1 = Factory.create(:mail, :sender => user)
+    mail_2 = Factory.create(:mail, :sender => user)
+
+    post(:delete_selected, :delete => [mail_1.id, mail_2.id])
+
+    mail_1.reload.sender_deleted.should be_true
+    mail_2.reload.sender_deleted.should be_true
+  end
+
+  it 'marks each mail deleted when user is recipient' do
+    user = User.anonymous
+    mail_1 = Factory.create(:mail, :recipient => user)
+    mail_2 = Factory.create(:mail, :recipient => user)
+
+    post(:delete_selected, :delete => [mail_1.id, mail_2.id])
+
+    mail_1.reload.recipient_deleted.should be_true
+    mail_2.reload.recipient_deleted.should be_true
+  end
+
+  it 'does not mark non-selected mail deleted' do
+    user = User.anonymous
+    mail_1 = Factory.create(:mail, :recipient => user)
+    mail_2 = Factory.create(:mail, :recipient => user)
+
+    post(:delete_selected, :delete => [mail_1.id])
+
+    mail_2.reload
+    mail_2.recipient_deleted.should be_false
+    mail_2.sender_deleted.should be_false
+  end
+
+  it 'does not mark mail deleted when user is not sender or recipient' do
+    user = User.anonymous
+    mail = Factory.create(:mail)
+
+    post(:delete_selected, :delete => [mail.id])
+
+    mail.reload
+    mail.recipient_deleted.should be_false
+    mail.sender_deleted.should be_false
+  end
+
+  it 'flashes a success message' do
+    user = User.anonymous
+
+    post(:delete_selected, :delete => [1])
+
+    flash[:success].should == 'Messages deleted'
+  end
+end

--- a/spec/factories/mails.rb
+++ b/spec/factories/mails.rb
@@ -1,0 +1,2 @@
+Factory.define :mail do |f|
+end


### PR DESCRIPTION
* removed the `if request.post?` because it is impossible for it not to
be a `POST` request. The route specifies `:post`, there is no
`delete_selected` view to render if it is *not* `POST`, and this is only
reached via a form post from `mails/index`.
* change `flash.now[:success]` to `flash[:success]`. `flash.now` only
displays if we immediately render after the action. It will be cleared
before it gets a chance to display if we redirect, which is what we're
doing. `flash[:success]`, on the other hand, is only cleared after the
redirect.
* switched the redirect at the tend to redirect to `mails/index`. It was
trying to redirect to `mails/show`, but passing in an instance variable
that is not defined. `mails/show` expects only a single mail, anyway. It
seems like we probably want to redirect to the `index` action instead
after deleting, since the mails are no longer there to show.
* It appears that the `:conditions` is not necessary with `Mail.find`
because `@mail.mark_deleted` only changes the record based on the
relationship the user has to the mail. If the user is not the sender or
recipient, then it will not be changed.
