### PR TITLE
add specs for IssueInvitationsController

### DIFF
--- a/app/controllers/issue_invitations_controller.rb
+++ b/app/controllers/issue_invitations_controller.rb
@@ -2,16 +2,15 @@
 # Copyright (C) 2006-2011  See readme for details and license#
 
 class IssueInvitationsController < ApplicationController
-  def new # spec_me cover_me heckle_me
+  def new # cover_me heckle_me
     @quote = Quote.new
 
     respond_to do |format|
-      format.html
       format.xml  { render :xml => @quote }
     end
   end
 
-  def create # spec_me cover_me heckle_me
+  def create # cover_me heckle_me
     @quote = Quote.new(params[:quote])
     @quote.user_id = User.current.id
 

--- a/spec/controllers/issue_invitations_controller/create_spec.rb
+++ b/spec/controllers/issue_invitations_controller/create_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe IssueInvitationsController, '#create' do
+  it 'assigns @quote' do
+    post(:create, :quote => { :author => 'me', :body => 'welp' })
+
+    quote = assigns(:quote)
+    quote.author.should == 'me'
+    quote.body.should == 'welp'
+  end
+
+  it 'sets the user on the quote' do
+    post(:create)
+
+    assigns(:quote).user_id.should == User.anonymous.id
+  end
+
+  it 'flashes a success message' do
+    flash.stub(:sweep)
+
+    post(:create)
+
+    flash.now[:success].should == 'Invitation was successfully created and sent'
+  end
+
+  it 'redirects to the quote' do
+    post(:create)
+
+    response.should redirect_to(quotes_path)
+  end
+
+  it 'renders the quote as xml when format is xml' do
+    quote_params = { :author => 'you', :body => 'yep' }
+
+    post(:create, :quote => quote_params, :format => 'xml')
+
+    test_quote = Quote.new(quote_params.merge(:user_id => User.anonymous.id))
+    response.body.should == test_quote.to_xml
+    response.status.should == "201 Created"
+    response.location.should == quotes_url
+  end
+end

--- a/spec/controllers/issue_invitations_controller/new_spec.rb
+++ b/spec/controllers/issue_invitations_controller/new_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe IssueInvitationsController, '#new' do
+  it 'renders a new quote as xml when format is xml' do
+    get(:new, :format => 'xml')
+
+    response.body.should == Quote.new.to_xml
+  end
+end


### PR DESCRIPTION
As near as I can tell, this controller is not used from anywhere in the
application. It looks like it just got added in during a JQuery upgrade
at one point. For now I've added tests, but down the road once we have
better feature testing, we may be able to remove it if we don't find any
usage.

I removed the `format.html` block from the `new` action because there is
no corresponding view file, so it will always throw an error if hit.
