### PR TITLE
Add specs for IssuesController#bulk_edit

### DIFF
--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -501,7 +501,7 @@ class IssuesController < ApplicationController
   end
 
   # Bulk edit a set of issues
-  def bulk_edit # spec_me cover_me heckle_me
+  def bulk_edit # cover_me heckle_me
     if request.post?
       tracker = params[:tracker_id].blank? ? nil : @project.trackers.find_by_id(params[:tracker_id])
       status = params[:status_id].blank? ? nil : IssueStatus.find_by_id(params[:status_id])
@@ -531,7 +531,6 @@ class IssuesController < ApplicationController
       redirect_to(params[:back_to] || {:controller => 'issues', :action => 'index', :project_id => @project})
       return
     end
-    @available_statuses = Workflow.available_statuses(@project)
   end
 
   def move # spec_me cover_me heckle_me

--- a/spec/controllers/issues_controller/bulk_edit_spec.rb
+++ b/spec/controllers/issues_controller/bulk_edit_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe IssuesController, '#bulk_edit' do
+  it 'raises an error when request is GET' do
+    user = Factory.create(:user)
+    issue = Factory.create(:issue)
+    login_as(user)
+
+    expect { get(:bulk_edit, :id => issue.id) }.
+      to raise_error(ActionView::MissingTemplate)
+  end
+
+  it 'sets the tracker when tracker_id is given' do
+    tracker = Factory.create(:tracker)
+    user = Factory.create(:user)
+    issue = Factory.create(:issue)
+    login_as(user)
+
+    post(:bulk_edit, :id => issue.id, :tracker_id => tracker.id)
+
+    issue.reload.tracker.should == tracker
+  end
+
+  it 'does not set tracker when invalid tracker_id is given' do
+    tracker_1 = Factory.create(:tracker)
+    issue = Factory.create(:issue, :tracker => tracker_1)
+    tracker_2 = Factory.create(:tracker)
+    user = Factory.create(:user)
+    login_as(user)
+
+    post(:bulk_edit, :id => issue.id, :tracker_id => tracker_2.id)
+
+    issue.reload.tracker.should == tracker_1
+  end
+
+  it 'does not set tracker to nil when no tracker_id is given' do
+    tracker = Factory.create(:tracker)
+    issue = Factory.create(:issue, :tracker => tracker)
+    user = Factory.create(:user)
+    login_as(user)
+
+    post(:bulk_edit, :id => issue.id)
+
+    issue.reload.tracker.should == tracker
+  end
+
+  it 'sets the status on the issue when status_id is given' do
+    status = Factory.create(:issue_status)
+    issue = Factory.create(:issue)
+    user = Factory.create(:user)
+    Factory.create(:workflow, :tracker => issue.tracker, :role => Role.non_member, :old_status => issue.status, :new_status => status)
+    login_as(user)
+
+    post(:bulk_edit, :id => issue.id, :status_id => status.id)
+
+    issue.reload.status.should == status
+  end
+end


### PR DESCRIPTION
There is no corresponding view, so if not `request.post?` it raises a
template error. As such `@available_statuses` will never get used. I
grepped around for it and the only other place it shows up is when it is
assigned in the `context_menu` action.
