### PR TITLE
Add specs for EmailUpdatesController#create

### DIFF
--- a/app/controllers/email_updates_controller.rb
+++ b/app/controllers/email_updates_controller.rb
@@ -10,7 +10,7 @@ class EmailUpdatesController < ApplicationController
     end
   end
 
-  def create # spec_me cover_me heckle_me
+  def create # cover_me heckle_me
     @email_update = EmailUpdate.new(params[:email_update])
     @email_update.user = User.current
 

--- a/app/models/email_update.rb
+++ b/app/models/email_update.rb
@@ -1,6 +1,8 @@
 class EmailUpdate < ActiveRecord::Base
   belongs_to :user
 
+  validates_presence_of :mail
+
   def before_create # heckle_me
     self.token = Token.generate_token_value
   end

--- a/spec/controllers/email_updates_controller/create_spec.rb
+++ b/spec/controllers/email_updates_controller/create_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+
+describe EmailUpdatesController, '#create' do
+  context 'when params are valid' do
+    it 'creates an email update' do
+      user = Factory.create(:user)
+      login_as(user)
+
+      expect { post(:create, :email_update => { :mail => 'blah' }) }.
+        to change(EmailUpdate, :count).by(1)
+
+      EmailUpdate.last.mail.should == 'blah'
+    end
+
+    it 'sets the user on the email update' do
+      user_1 = Factory.create(:user)
+      user_2 = Factory.create(:user)
+      login_as(user_1)
+
+      post(:create, :email_update => { :user_id => user_2.id, :mail => 'boo@boo.com' })
+
+      EmailUpdate.last.user.should == user_1
+    end
+
+    def expect_enqueued_job(object, method, *args)
+      job = Delayed::Job.first
+      payload = job.payload_object
+      payload.should == Delayed::PerformableMethod.new(object, method, args)
+    end
+
+    it 'sends an activation email' do
+      user = Factory.create(:user)
+      login_as(user)
+
+      expect { post(:create, :email_update => { :mail => 'boo@boo.com' }) }.
+        to change(Delayed::Job, :count).by(1)
+
+      expect_enqueued_job(Mailer, :deliver_email_update_activation, EmailUpdate.last)
+    end
+
+    it 'flashes a success message' do
+      user = Factory.create(:user)
+      login_as(user)
+
+      post(:create, :email_update => { :mail => 'boo@boo.com' })
+
+      flash[:success].should == 'Please check boo@boo.com for the activation email'
+    end
+
+    it 'redirects to my account' do
+      user = Factory.create(:user)
+      login_as(user)
+
+      post(:create, :email_update => { :mail => 'boo@boo.com' })
+
+      response.should redirect_to(:controller => :my, :action => :account)
+
+    end
+  end
+
+  context 'when params are invalid' do
+    it 'flashes an error message' do
+      flash.stub(:sweep)
+      user = Factory.create(:user)
+      login_as(user)
+
+      post(:create)
+
+      flash.now[:error].should == "Couldn't create email update"
+    end
+
+    it 'renders the new page' do
+      user = Factory.create(:user)
+      login_as(user)
+
+      post(:create)
+
+      response.body.should include('Your new email address')
+    end
+  end
+end

--- a/spec/models/email_update/accept_spec.rb
+++ b/spec/models/email_update/accept_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe EmailUpdate, '#accept' do
 
-  let(:email_update) { EmailUpdate.create!(:activated => false) }
+  let(:email_update) { EmailUpdate.create!(:activated => false, :mail => 'b@b.com') }
 
   before(:each) { Mailer.stub(:send_later) }
 

--- a/spec/models/email_update/send_activation_spec.rb
+++ b/spec/models/email_update/send_activation_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe EmailUpdate, '#send_activation' do
 
-  let(:email_update) { EmailUpdate.create!(:activated => false) }
+  let(:email_update) { EmailUpdate.create!(:activated => false, :mail => 'b@b.com') }
 
   before(:each) { Mailer.stub(:send_later) }
 


### PR DESCRIPTION
Added a validation on `EmailUpdate#mail`, since it doesn't make much
sense to have an email update without an email. It also makes it so that
we can test the error cases in the controller.
